### PR TITLE
Improve Vec3.toString() method.

### DIFF
--- a/docs/vec3.md
+++ b/docs/vec3.md
@@ -89,8 +89,8 @@ Calculates the shortest distance from the vector to a line segment.
 ### `equals(other)`
 Checks if the current vector is equal to another vector.
 
-### `toString()`
-Returns a string representation of the vector.
+### `toString(format, separator)`
+Returns a string representation of the vector. Format being either `short` *"x, y, z"* or `long` *"Vec3(x, y, z)"* default being `long` with `", "` as a separator.
 
 ## Usage Example
 ```javascript

--- a/src/Vec3.test.ts
+++ b/src/Vec3.test.ts
@@ -748,5 +748,24 @@ describe('Vec3', () => {
     expect(vec1.almostEqual(1.1, 2.1, 3.1, 0.2)).toBe(true);
   });
 
+  it('should return "Vec3(1, 1, 1)" when `Vec3.toString()` is called with default values', () => {
+    const vec = new Vec3(1, 1, 1);
+    expect(vec.toString()).toEqual('Vec3(1, 1, 1)');
+  });
+
+  it('should return "Vec3(1;2;3)" when `Vec3.toString()` is called with "long" format and ";" as separator', () => {
+    const vec = new Vec3(1, 2, 3);
+    expect(vec.toString('long', ';')).toEqual('Vec3(1;2;3)');
+  });
+
+  it('should return "1, 1, 1" when `Vec3.toString()` is called with "short" format', () => {
+    const vec = new Vec3(1, 1, 1);
+    expect(vec.toString('short')).toEqual('1, 1, 1');
+  });
+
+  it('should return "1;2;3" when `Vec3.toString()` is called with "short" format and ";" as separator', () => {
+    const vec = new Vec3(1, 2, 3);
+    expect(vec.toString('short', ';')).toEqual('1;2;3');
+  });
 
 });

--- a/src/Vec3.ts
+++ b/src/Vec3.ts
@@ -694,7 +694,8 @@ export default class Vec3 implements Vector3 {
     }
   }
 
-  toString() {
-    return `Vec3(${this.x}, ${this.y}, ${this.z})`;
+  toString(format: 'long'|'short' = 'long', separator: string = ', '): string {
+    const result = `${this.x + separator + this.y + separator + this.z}`;
+    return format === 'long' ? `Vec3(${result})` : result;
   }
 }


### PR DESCRIPTION
Improves toString method by adding `format` and `separator` values. Method includes default values for maintaining backwards compatibility.

This PR adds test and documentation for this extended method.